### PR TITLE
release 0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,15 @@
 ~
 
-v0.1.0 (2020-03-16) [First Release]
+### v0.2.0 (2020-12-31)
+* adds "Calendar Integration" (#1). This feature requires "Suntimes Calendars" v0.5.0.
+* adds bottom sheet; shows an expanded view with note explaining the reasons for a daily rating.
+* adds "Share" menu item; shares a daily rating as text.
+* adds "Go to..." menu item; scrolls to a given date.
+* adds "View Date" menu item; opens Suntimes to a given date.
+* adds Time Zone selector; "System", "Suntimes", "Apparent Solar", and "Local Mean".
+* modifies the range of cards to +-10 years.
+
+### v0.1.0 (2020-03-16) [First Release]
 * an add-on app that uses the current Suntimes configuration (location, timezone, theme, locale, and UI options). The minimum Suntimes version is `v0.10.3` (but without access to UI options); the recommended version is `v0.12.6`.
 * UI provides an ActionBar that displays configured Location (lat, lon, alt), Suntimes icon (opens Suntimes activity), and overflow menu (Help, and About).
 * UI provides a BottomBar that displays the configured timezone. 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -26,7 +26,7 @@ dependencies {
     implementation 'com.android.support:design:28.0.0'
     implementation 'com.android.support:support-v4:28.0.0'
     implementation 'com.android.support:support-vector-drawable:28.0.0'
-    implementation 'com.github.forrestguice:SuntimesAddon:c34710a550'
+    implementation 'com.github.forrestguice:SuntimesAddon:v0.2.0'
 
     testImplementation 'junit:junit:4.12'
     androidTestImplementation 'com.android.support.test:runner:1.0.2'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -6,8 +6,8 @@ android {
         applicationId "com.forrestguice.suntimes.solunar"
         minSdkVersion 14
         targetSdkVersion 28
-        versionCode 1
-        versionName "0.1.0"
+        versionCode 2
+        versionName "0.2.0"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true
         buildConfigField "String", "GIT_HASH", "\"${getGitHash()}\""

--- a/fastlane/metadata/android/en-US/changelogs/1.txt
+++ b/fastlane/metadata/android/en-US/changelogs/1.txt
@@ -1,0 +1,1 @@
+- Initial release. The recommended Suntimes version is `v0.12.6` or greater.

--- a/fastlane/metadata/android/en-US/changelogs/2.txt
+++ b/fastlane/metadata/android/en-US/changelogs/2.txt
@@ -1,0 +1,4 @@
+- adds "Calendar Integration". This feature requires "Suntimes Calendars" v0.5.0.
+- adds a bottom sheet that explains the reasons for a daily rating.
+- adds menu items to "Share" (as text), "Go to..." (scroll), and "View Date" (open in Suntimes).
+- adds a time zone selector; "System", "Suntimes", "Apparent Solar", or "Local Mean".


### PR DESCRIPTION
* adds "Calendar Integration" (closes #1). This feature requires "Suntimes Calendars" v0.5.0.
* adds bottom sheet; shows an expanded view with note explaining the reasons for a daily rating.
* adds "Share" menu item; shares a daily rating as text.
* adds "Go to..." menu item; scrolls to a given date.
* adds "View Date" menu item; opens Suntimes to a given date.
* adds Time Zone selector; "System", "Suntimes", "Apparent Solar", and "Local Mean".
* modifies the range of cards to +-10 years.