### PR TITLE
release 0.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,6 @@
 ~
 
 ### v0.2.1 (2023-8-21)
-* adds support for "utc" time zone.
 * adds support for system theme (night mode), high contrast app themes, and "text size" settings.
 * fixes crash when using "calendar integration" menu item (#6).
 * updates build; targetSdkVersion 28 -> 33; Gradle 4.4 -> 6.5; Android Gradle Plugin 3.1.3 -> 4.1.3; migrates from legacy support libraries to AndroidX.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ~
 
+### v0.2.1 (2023-8-21)
+* adds support for "utc" time zone.
+* adds support for system theme (night mode), high contrast app themes, and "text size" settings.
+* fixes crash when using "calendar integration" menu item (#6).
+* updates build; targetSdkVersion 28 -> 33; Gradle 4.4 -> 6.5; Android Gradle Plugin 3.1.3 -> 4.1.3; migrates from legacy support libraries to AndroidX.
+
 ### v0.2.0 (2020-12-31)
 * adds "Calendar Integration" (#1). This feature requires "Suntimes Calendars" v0.5.0.
 * adds bottom sheet; shows an expanded view with note explaining the reasons for a daily rating.

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -7,8 +7,8 @@ android {
         minSdkVersion 14
         //noinspection OldTargetApi
         targetSdkVersion 33
-        versionCode 2
-        versionName "0.2.0"
+        versionCode 3
+        versionName "0.2.1"
         testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
         vectorDrawables.useSupportLibrary = true
         buildConfigField "String", "GIT_HASH", "\"${getGitHash()}\""

--- a/fastlane/metadata/android/en-US/changelogs/3.txt
+++ b/fastlane/metadata/android/en-US/changelogs/3.txt
@@ -1,0 +1,4 @@
+- adds support for "utc" time zone.
+- adds support for system theme (night mode), high contrast app themes, and "text size" settings.
+- fixes crash when using "calendar integration" menu item (#6).
+- updates the targetSdkVersion (28 -> 33) and migrates the app to AndroidX.

--- a/fastlane/metadata/android/en-US/changelogs/3.txt
+++ b/fastlane/metadata/android/en-US/changelogs/3.txt
@@ -1,4 +1,3 @@
-- adds support for "utc" time zone.
 - adds support for system theme (night mode), high contrast app themes, and "text size" settings.
 - fixes crash when using "calendar integration" menu item (#6).
 - updates the targetSdkVersion (28 -> 33) and migrates the app to AndroidX.


### PR DESCRIPTION
* adds support for system theme (night mode), high contrast app themes, and "text size" settings.
* fixes crash when using "calendar integration" menu item (closes #6).
* updates build; targetSdkVersion 28 -> 33; Gradle 4.4 -> 6.5; Android Gradle Plugin 3.1.3 -> 4.1.3; migrates from legacy support libraries to AndroidX