### PR TITLE
release 0.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * adds exception handler and crash report notification.
 * adds "online help" button (https://forrestguice.github.io/Suntimes/help/addons/solunarperiods).
 * updates build; targetSdkVersion 33 -> 34; Gradle 6.5 -> 8.7; Android Gradle Plugin 4.1.3 -> 8.5.2.
+* updates build; adds nightly build flavor (#9).
 
 ### v0.2.1 (2023-08-21)
 * adds support for system theme (night mode), high contrast app themes, and "text size" settings.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,11 @@
 ~
 
-### v0.2.2 (2026-04-08)
+### v0.2.2 (2026-04-27)
 * adds support for "Material You" (needs Suntimes v0.17.0+).
+* adds support for "show coordinates" option (needs Suntimes v0.17.0+).
 * adds exception handler and crash report notification.
 * adds "online help" button (https://forrestguice.github.io/Suntimes/help/addons/solunarperiods).
-* updates build; targetSdkVersion 33 -> 34; Gradle 6.5 -> 8.7; Android Gradle Plugin 4.1.3 -> 8.5.2.
+* updates build; targetSdkVersion 33 -> 34 (Android 14); Gradle 6.5 -> 8.7; Android Gradle Plugin 4.1.3 -> 8.5.2.
 * updates build; adds nightly build flavor (#9).
 
 ### v0.2.1 (2023-08-21)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 ~
 
-### v0.2.1 (2023-8-21)
+### v0.2.2 (2026-04-08)
+* adds support for "Material You" (needs Suntimes v0.17.0+).
+* adds exception handler and crash report notification.
+* adds "online help" button (https://forrestguice.github.io/Suntimes/help/addons/solunarperiods).
+* updates build; targetSdkVersion 33 -> 34; Gradle 6.5 -> 8.7; Android Gradle Plugin 4.1.3 -> 8.5.2.
+
+### v0.2.1 (2023-08-21)
 * adds support for system theme (night mode), high contrast app themes, and "text size" settings.
 * fixes crash when using "calendar integration" menu item (#6).
 * updates build; targetSdkVersion 28 -> 33; Gradle 4.4 -> 6.5; Android Gradle Plugin 3.1.3 -> 4.1.3; migrates from legacy support libraries to AndroidX.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ~
 
-### v0.2.2 (2026-04-27)
+### v0.2.2 (2026-06-18)
 * adds support for "Material You" (needs Suntimes v0.17.0+).
 * adds support for "show coordinates" option (needs Suntimes v0.17.0+).
 * adds exception handler and crash report notification.

--- a/README.md
+++ b/README.md
@@ -17,9 +17,9 @@ This app displays sunrise, sunset, moonrise, moonset, lunar noon, lunar midnight
 ## Donations ##
 Do you find value in this software? Please pay as you feel.
 
-[![paypal](https://www.paypalobjects.com/webstatic/en_US/i/btn/png/silver-rect-paypal-26px.png)](https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=NZJ5FJBCKY6K2)
-
 <noscript><a href="https://liberapay.com/forrestguice/donate"><img alt="Donate using Liberapay" src="https://liberapay.com/assets/widgets/donate.svg"></a></noscript>
+
+[![paypal](https://www.paypalobjects.com/webstatic/en_US/i/btn/png/silver-rect-paypal-26px.png)](https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=NZJ5FJBCKY6K2)
 
 
 ## Bug Reports ##
@@ -33,7 +33,7 @@ Solunar Periods does not collect, store, or transmit personal user data. It cont
 __Solunar Periods is an addon for Suntimes.__ It uses the `suntimes.permission.READ_CALCULATOR` permission in order to access data provided by this app. https://github.com/forrestguice/SuntimesWidget/wiki/Privacy
 
 ## Legal Stuff
-Copyright (C) 2020-2025 **Forrest Guice**
+Copyright (C) 2020-2026 **Forrest Guice**
 ```
 SolunarPeriods is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -14,8 +14,8 @@ android {
         targetSdkVersion 34
         compileSdk 34
 
-        versionCode 3
-        versionName "0.2.1"
+        versionCode 4
+        versionName "0.2.2"
 
         testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
         vectorDrawables.useSupportLibrary = true

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -15,7 +15,7 @@
 
     <string name="app_legal1"><![CDATA[
         <b>Source Code:</b><br />
-        Copyright &#169 2020-2025 Forrest Guice <br />
+        Copyright &#169 2020-2026 Forrest Guice <br />
         Source code available under GPLv3.
     ]]></string>
 

--- a/fastlane/metadata/android/en-US/changelogs/4.txt
+++ b/fastlane/metadata/android/en-US/changelogs/4.txt
@@ -1,4 +1,5 @@
 - adds support for "Material You" (needs Suntimes v0.17.0+).
+- adds support for "show coordinates" option (needs Suntimes v0.17.0+).
 - adds crash report notification.
 - adds "online help" button.
-- updates targetSdk to Android 14 (api 34).
+- updates targetSdk to Android 14.

--- a/fastlane/metadata/android/en-US/changelogs/4.txt
+++ b/fastlane/metadata/android/en-US/changelogs/4.txt
@@ -1,0 +1,4 @@
+- adds support for "Material You" (needs Suntimes v0.17.0+).
+- adds crash report notification.
+- adds "online help" button.
+- updates targetSdk to Android 14 (api 34).


### PR DESCRIPTION
* adds support for "Material You" (needs Suntimes v0.17.0+).
* adds exception handler and crash report notification.
* adds "online help" button (https://forrestguice.github.io/Suntimes/help/addons/solunarperiods).
* updates build; targetSdkVersion 33 -> 34; Gradle 6.5 -> 8.7; Android Gradle Plugin 4.1.3 -> 8.5.2.
* updates build; adds nightly build flavor (#9).